### PR TITLE
[FEAT] #14 리뷰 및 영수증 관련 엔티티 생성 

### DIFF
--- a/src/main/java/com/lokoko/domain/image/entity/ReceiptImage.java
+++ b/src/main/java/com/lokoko/domain/image/entity/ReceiptImage.java
@@ -1,7 +1,12 @@
 package com.lokoko.domain.image.entity;
 
-import com.lokoko.domain.review.entity.Review;
+import org.springframework.jdbc.support.MetaDataAccessException;
 
+import com.lokoko.domain.review.entity.Review;
+import com.lokoko.global.common.entity.MediaFile;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -21,11 +26,11 @@ public class ReceiptImage {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "receipt_image_id")
 	private Long id;
 
-	private String fileName; // 영수증 이미지 파일 이름
-
-	private String fileUrl; // S3 상 영수증 이미지 파일 경로
+	@Embedded
+	private MediaFile mediaFile; // 파일 이름, 파일 경로 포함하는 값 타임 객체
 
 	private int displayOrder; // 배치순서
 
@@ -36,8 +41,7 @@ public class ReceiptImage {
 	public static ReceiptImage createReceiptImage(String fileName,
 		String fileUrl, int displayOrder, Review review) {
 		return ReceiptImage.builder()
-			.fileName(fileName)
-			.fileUrl(fileUrl)
+			.mediaFile(MediaFile.of(fileName, fileUrl))
 			.displayOrder(displayOrder)
 			.review(review)
 			.build();

--- a/src/main/java/com/lokoko/domain/image/entity/ReceiptImage.java
+++ b/src/main/java/com/lokoko/domain/image/entity/ReceiptImage.java
@@ -1,0 +1,47 @@
+package com.lokoko.domain.image.entity;
+
+import com.lokoko.domain.review.entity.Review;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Entity
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReceiptImage {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String fileName; // 영수증 이미지 파일 이름
+
+	private String fileUrl; // S3 상 영수증 이미지 파일 경로
+
+	private int displayOrder; // 배치순서
+
+	@ManyToOne
+	@JoinColumn(name = "review_id")
+	private Review review; // 영수증이 어떤 리뷰에 대한 것인지 (외래키)
+
+	public static ReceiptImage createReceiptImage(String fileName,
+		String fileUrl, int displayOrder, Review review) {
+		return ReceiptImage.builder()
+			.fileName(fileName)
+			.fileUrl(fileUrl)
+			.displayOrder(displayOrder)
+			.review(review)
+			.build();
+	}
+
+
+}

--- a/src/main/java/com/lokoko/domain/image/entity/ReceiptImage.java
+++ b/src/main/java/com/lokoko/domain/image/entity/ReceiptImage.java
@@ -1,10 +1,7 @@
 package com.lokoko.domain.image.entity;
 
-import org.springframework.jdbc.support.MetaDataAccessException;
-
 import com.lokoko.domain.review.entity.Review;
 import com.lokoko.global.common.entity.MediaFile;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -24,28 +21,26 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReceiptImage {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "receipt_image_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "receipt_image_id")
+    private Long id;
 
-	@Embedded
-	private MediaFile mediaFile; // 파일 이름, 파일 경로 포함하는 값 타임 객체
+    @Embedded
+    private MediaFile mediaFile; // 파일 이름, 파일 경로 포함하는 값 타임 객체
 
-	private int displayOrder; // 배치순서
+    private int displayOrder; // 배치순서
 
-	@ManyToOne
-	@JoinColumn(name = "review_id")
-	private Review review; // 영수증이 어떤 리뷰에 대한 것인지 (외래키)
+    @ManyToOne
+    @JoinColumn(name = "review_id")
+    private Review review; // 영수증이 어떤 리뷰에 대한 것인지 (외래키)
 
-	public static ReceiptImage createReceiptImage(String fileName,
-		String fileUrl, int displayOrder, Review review) {
-		return ReceiptImage.builder()
-			.mediaFile(MediaFile.of(fileName, fileUrl))
-			.displayOrder(displayOrder)
-			.review(review)
-			.build();
-	}
-
-
+    public static ReceiptImage createReceiptImage(String fileName,
+                                                  String fileUrl, int displayOrder, Review review) {
+        return ReceiptImage.builder()
+                .mediaFile(MediaFile.of(fileName, fileUrl))
+                .displayOrder(displayOrder)
+                .review(review)
+                .build();
+    }
 }

--- a/src/main/java/com/lokoko/domain/image/entity/ReceiptImage.java
+++ b/src/main/java/com/lokoko/domain/image/entity/ReceiptImage.java
@@ -1,5 +1,7 @@
 package com.lokoko.domain.image.entity;
 
+import static jakarta.persistence.FetchType.LAZY;
+
 import com.lokoko.domain.review.entity.Review;
 import com.lokoko.global.common.entity.MediaFile;
 import jakarta.persistence.Column;
@@ -31,7 +33,7 @@ public class ReceiptImage {
 
     private int displayOrder; // 배치순서
 
-    @ManyToOne
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "review_id")
     private Review review; // 영수증이 어떤 리뷰에 대한 것인지 (외래키)
 

--- a/src/main/java/com/lokoko/domain/image/entity/ReviewImage.java
+++ b/src/main/java/com/lokoko/domain/image/entity/ReviewImage.java
@@ -2,7 +2,6 @@ package com.lokoko.domain.image.entity;
 
 import com.lokoko.domain.review.entity.Review;
 import com.lokoko.global.common.entity.MediaFile;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -22,28 +21,26 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReviewImage {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "review_image_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_image_id")
+    private Long id;
 
-	@Embedded
-	private MediaFile mediaFile; // 파일 이름, 파일 경로 포함하는 값 타임 객체
+    @Embedded
+    private MediaFile mediaFile; // 파일 이름, 파일 경로 포함하는 값 타임 객체
 
-	private int displayOrder; // 배치순서
+    private int displayOrder; // 배치순서
 
-	@ManyToOne
-	@JoinColumn(name = "review_id")
-	private Review review; // 이미지가 어떤 리뷰에 대한 것인지 (외래키)
+    @ManyToOne
+    @JoinColumn(name = "review_id")
+    private Review review; // 이미지가 어떤 리뷰에 대한 것인지 (외래키)
 
-	public static ReviewImage createReviewImage(String fileName,
-		String fileUrl, int displayOrder, Review review) {
-		return ReviewImage.builder()
-			.mediaFile(MediaFile.of(fileName, fileUrl))
-			.displayOrder(displayOrder)
-			.review(review)
-			.build();
-	}
-
-
+    public static ReviewImage createReviewImage(String fileName,
+                                                String fileUrl, int displayOrder, Review review) {
+        return ReviewImage.builder()
+                .mediaFile(MediaFile.of(fileName, fileUrl))
+                .displayOrder(displayOrder)
+                .review(review)
+                .build();
+    }
 }

--- a/src/main/java/com/lokoko/domain/image/entity/ReviewImage.java
+++ b/src/main/java/com/lokoko/domain/image/entity/ReviewImage.java
@@ -1,5 +1,7 @@
 package com.lokoko.domain.image.entity;
 
+import static jakarta.persistence.FetchType.LAZY;
+
 import com.lokoko.domain.review.entity.Review;
 import com.lokoko.global.common.entity.MediaFile;
 import jakarta.persistence.Column;
@@ -31,7 +33,7 @@ public class ReviewImage {
 
     private int displayOrder; // 배치순서
 
-    @ManyToOne
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "review_id")
     private Review review; // 이미지가 어떤 리뷰에 대한 것인지 (외래키)
 

--- a/src/main/java/com/lokoko/domain/image/entity/ReviewImage.java
+++ b/src/main/java/com/lokoko/domain/image/entity/ReviewImage.java
@@ -1,0 +1,49 @@
+package com.lokoko.domain.image.entity;
+
+import com.lokoko.domain.review.entity.Review;
+import com.lokoko.global.common.entity.MediaFile;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Entity
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReviewImage {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "review_image_id")
+	private Long id;
+
+	@Embedded
+	private MediaFile mediaFile; // 파일 이름, 파일 경로 포함하는 값 타임 객체
+
+	private int displayOrder; // 배치순서
+
+	@ManyToOne
+	@JoinColumn(name = "review_id")
+	private Review review; // 이미지가 어떤 리뷰에 대한 것인지 (외래키)
+
+	public static ReviewImage createReviewImage(String fileName,
+		String fileUrl, int displayOrder, Review review) {
+		return ReviewImage.builder()
+			.mediaFile(MediaFile.of(fileName, fileUrl))
+			.displayOrder(displayOrder)
+			.review(review)
+			.build();
+	}
+
+
+}

--- a/src/main/java/com/lokoko/domain/image/repository/ReceiptImageRepository.java
+++ b/src/main/java/com/lokoko/domain/image/repository/ReceiptImageRepository.java
@@ -1,8 +1,7 @@
 package com.lokoko.domain.image.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.lokoko.domain.image.entity.ReceiptImage;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReceiptImageRepository extends JpaRepository<ReceiptImage, Long> {
 }

--- a/src/main/java/com/lokoko/domain/image/repository/ReceiptImageRepository.java
+++ b/src/main/java/com/lokoko/domain/image/repository/ReceiptImageRepository.java
@@ -1,0 +1,8 @@
+package com.lokoko.domain.image.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.lokoko.domain.image.entity.ReceiptImage;
+
+public interface ReceiptImageRepository extends JpaRepository<ReceiptImage, Long> {
+}

--- a/src/main/java/com/lokoko/domain/image/repository/ReceiptImageRepository.java
+++ b/src/main/java/com/lokoko/domain/image/repository/ReceiptImageRepository.java
@@ -2,6 +2,8 @@ package com.lokoko.domain.image.repository;
 
 import com.lokoko.domain.image.entity.ReceiptImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ReceiptImageRepository extends JpaRepository<ReceiptImage, Long> {
 }

--- a/src/main/java/com/lokoko/domain/image/repository/ReviewImageRepository.java
+++ b/src/main/java/com/lokoko/domain/image/repository/ReviewImageRepository.java
@@ -1,0 +1,8 @@
+package com.lokoko.domain.image.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.lokoko.domain.image.entity.ReviewImage;
+
+public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
+}

--- a/src/main/java/com/lokoko/domain/image/repository/ReviewImageRepository.java
+++ b/src/main/java/com/lokoko/domain/image/repository/ReviewImageRepository.java
@@ -2,6 +2,8 @@ package com.lokoko.domain.image.repository;
 
 import com.lokoko.domain.image.entity.ReviewImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
 }

--- a/src/main/java/com/lokoko/domain/image/repository/ReviewImageRepository.java
+++ b/src/main/java/com/lokoko/domain/image/repository/ReviewImageRepository.java
@@ -1,8 +1,7 @@
 package com.lokoko.domain.image.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.lokoko.domain.image.entity.ReviewImage;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
 }

--- a/src/main/java/com/lokoko/domain/like/entity/ReviewLike.java
+++ b/src/main/java/com/lokoko/domain/like/entity/ReviewLike.java
@@ -1,0 +1,54 @@
+package com.lokoko.domain.like.entity;
+
+import com.lokoko.domain.review.entity.Review;
+import com.lokoko.domain.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * 리뷰 좋아요
+ */
+@Getter
+@Entity
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = {
+	@UniqueConstraint(name = "uk_review_like_review_user", columnNames = {"review_id", "user_id"})
+}) // (리뷰, 유저) 에 대해 유니크 제약조건 설정하여 같은 유저가 여러번 좋아요 누를 수 없도록 설정.
+public class ReviewLike {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "review_like_id")
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "review_id") // foreign key
+	private Review review; // 어떤 리뷰에 대한 좋아요인지
+
+	@ManyToOne
+	@JoinColumn(name = "user_id") //  foreign key
+	private User user;  // 어떤 회원이 좋아요를 눌렀는지
+
+	// 정적 팩토리 메소드
+	public static ReviewLike createReviewLike(Review review, User user) {
+		return ReviewLike.builder()
+			.review(review)
+			.user(user)
+			.build();
+	}
+
+}

--- a/src/main/java/com/lokoko/domain/like/entity/ReviewLike.java
+++ b/src/main/java/com/lokoko/domain/like/entity/ReviewLike.java
@@ -1,8 +1,9 @@
 package com.lokoko.domain.like.entity;
 
+import static jakarta.persistence.FetchType.LAZY;
+
 import com.lokoko.domain.review.entity.Review;
 import com.lokoko.domain.user.entity.User;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -13,7 +14,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -26,29 +26,29 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(uniqueConstraints = {
-	@UniqueConstraint(name = "uk_review_like_review_user", columnNames = {"review_id", "user_id"})
+        @UniqueConstraint(name = "uk_review_like_review_user", columnNames = {"review_id", "user_id"})
 }) // (리뷰, 유저) 에 대해 유니크 제약조건 설정하여 같은 유저가 여러번 좋아요 누를 수 없도록 설정.
 public class ReviewLike {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "review_like_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_like_id")
+    private Long id;
 
-	@ManyToOne
-	@JoinColumn(name = "review_id") // foreign key
-	private Review review; // 어떤 리뷰에 대한 좋아요인지
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "review_id") // foreign key
+    private Review review; // 어떤 리뷰에 대한 좋아요인지
 
-	@ManyToOne
-	@JoinColumn(name = "user_id") //  foreign key
-	private User user;  // 어떤 회원이 좋아요를 눌렀는지
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id") //  foreign key
+    private User user;  // 어떤 회원이 좋아요를 눌렀는지
 
-	// 정적 팩토리 메소드
-	public static ReviewLike createReviewLike(Review review, User user) {
-		return ReviewLike.builder()
-			.review(review)
-			.user(user)
-			.build();
-	}
+    // 정적 팩토리 메소드
+    public static ReviewLike createReviewLike(Review review, User user) {
+        return ReviewLike.builder()
+                .review(review)
+                .user(user)
+                .build();
+    }
 
 }

--- a/src/main/java/com/lokoko/domain/like/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/lokoko/domain/like/repository/ReviewLikeRepository.java
@@ -1,0 +1,9 @@
+package com.lokoko.domain.like.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.lokoko.domain.like.entity.ReviewLike;
+
+public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
+}

--- a/src/main/java/com/lokoko/domain/like/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/lokoko/domain/like/repository/ReviewLikeRepository.java
@@ -1,9 +1,7 @@
 package com.lokoko.domain.like.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
 import com.lokoko.domain.like.entity.ReviewLike;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
 }

--- a/src/main/java/com/lokoko/domain/like/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/lokoko/domain/like/repository/ReviewLikeRepository.java
@@ -2,6 +2,8 @@ package com.lokoko.domain.like.repository;
 
 import com.lokoko.domain.like.entity.ReviewLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
 }

--- a/src/main/java/com/lokoko/domain/review/entity/Review.java
+++ b/src/main/java/com/lokoko/domain/review/entity/Review.java
@@ -1,5 +1,7 @@
 package com.lokoko.domain.review.entity;
 
+import static jakarta.persistence.FetchType.LAZY;
+
 import com.lokoko.domain.user.entity.User;
 import com.lokoko.global.common.entity.BaseEntity;
 import jakarta.persistence.Column;
@@ -25,7 +27,7 @@ public class Review extends BaseEntity {
     @Column(name = "review_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id")
     private User author; // 리뷰 작성자 foreign key 매핑
 

--- a/src/main/java/com/lokoko/domain/review/entity/Review.java
+++ b/src/main/java/com/lokoko/domain/review/entity/Review.java
@@ -1,0 +1,66 @@
+package com.lokoko.domain.review.entity;
+
+import com.lokoko.domain.user.entity.User;
+import com.lokoko.global.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Entity
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Review extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "review_id")
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "user_id")
+	private User author; // 리뷰 작성자 foreign key 매핑
+
+	// Product 엔티티가 만들어지고 난 후, 주석 해제 해야합니다.
+	// @ManyToOne
+	// @JoinColumn(name = "product_id")
+	// private Product product;
+
+	private String positiveContent; // 긍정 리뷰 내용
+
+	private String negativeContent; // 부정 리뷰 내용
+
+	private int likeCount; // 좋아요 수
+
+	public static Review createReview(User user, String positive, String negative) {
+		return Review.builder()
+			.author(user)
+			.positiveContent(positive)
+			.negativeContent(negative)
+			.build();
+	}
+
+	// 긍정 리뷰 내용 수정
+	public void changePositiveContent(String content) {
+		this.positiveContent = content;
+	}
+
+	// 부정 리뷰 내용 수정
+	public void changeNegativeContent(String content) {
+		this.negativeContent = content;
+	}
+
+
+
+}

--- a/src/main/java/com/lokoko/domain/review/entity/Review.java
+++ b/src/main/java/com/lokoko/domain/review/entity/Review.java
@@ -2,7 +2,6 @@ package com.lokoko.domain.review.entity;
 
 import com.lokoko.domain.user.entity.User;
 import com.lokoko.global.common.entity.BaseEntity;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -10,9 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -23,44 +20,41 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Review extends BaseEntity {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "review_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_id")
+    private Long id;
 
-	@ManyToOne
-	@JoinColumn(name = "user_id")
-	private User author; // 리뷰 작성자 foreign key 매핑
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User author; // 리뷰 작성자 foreign key 매핑
 
-	// Product 엔티티가 만들어지고 난 후, 주석 해제 해야합니다.
-	// @ManyToOne
-	// @JoinColumn(name = "product_id")
-	// private Product product;
+    // Product 엔티티가 만들어지고 난 후, 주석 해제 해야합니다.
+    // @ManyToOne
+    // @JoinColumn(name = "product_id")
+    // private Product product;
 
-	private String positiveContent; // 긍정 리뷰 내용
+    private String positiveContent; // 긍정 리뷰 내용
 
-	private String negativeContent; // 부정 리뷰 내용
+    private String negativeContent; // 부정 리뷰 내용
 
-	private int likeCount; // 좋아요 수
+    private int likeCount; // 좋아요 수
 
-	public static Review createReview(User user, String positive, String negative) {
-		return Review.builder()
-			.author(user)
-			.positiveContent(positive)
-			.negativeContent(negative)
-			.build();
-	}
+    public static Review createReview(User user, String positive, String negative) {
+        return Review.builder()
+                .author(user)
+                .positiveContent(positive)
+                .negativeContent(negative)
+                .build();
+    }
 
-	// 긍정 리뷰 내용 수정
-	public void changePositiveContent(String content) {
-		this.positiveContent = content;
-	}
+    // 긍정 리뷰 내용 수정
+    public void changePositiveContent(String content) {
+        this.positiveContent = content;
+    }
 
-	// 부정 리뷰 내용 수정
-	public void changeNegativeContent(String content) {
-		this.negativeContent = content;
-	}
-
-
-
+    // 부정 리뷰 내용 수정
+    public void changeNegativeContent(String content) {
+        this.negativeContent = content;
+    }
 }

--- a/src/main/java/com/lokoko/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/lokoko/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,8 @@
+package com.lokoko.domain.review.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.lokoko.domain.review.entity.Review;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/src/main/java/com/lokoko/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/lokoko/domain/review/repository/ReviewRepository.java
@@ -1,8 +1,7 @@
 package com.lokoko.domain.review.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.lokoko.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 }

--- a/src/main/java/com/lokoko/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/lokoko/domain/review/repository/ReviewRepository.java
@@ -2,6 +2,8 @@ package com.lokoko.domain.review.repository;
 
 import com.lokoko.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 }

--- a/src/main/java/com/lokoko/domain/video/entity/ReviewVideo.java
+++ b/src/main/java/com/lokoko/domain/video/entity/ReviewVideo.java
@@ -1,0 +1,50 @@
+package com.lokoko.domain.video.entity;
+
+import com.lokoko.domain.image.entity.ReceiptImage;
+import com.lokoko.domain.review.entity.Review;
+import com.lokoko.global.common.entity.MediaFile;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Entity
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReviewVideo {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "review_video_id")
+	private Long id;
+
+	@Embedded
+	private MediaFile mediaFile; // 파일 이름, 파일 경로 포함
+
+	private int displayOrder; // 배치순서
+
+	@ManyToOne
+	@JoinColumn(name = "review_id")
+	private Review review; // 동영상이 어떤 리뷰에 대한 것인지 (외래키)
+
+	public static ReviewVideo createReviewVideo(String fileName,
+		String fileUrl, int displayOrder, Review review) {
+		return ReviewVideo.builder()
+			.mediaFile(MediaFile.of(fileName, fileUrl))
+			.displayOrder(displayOrder)
+			.review(review)
+			.build();
+	}
+
+
+}

--- a/src/main/java/com/lokoko/domain/video/entity/ReviewVideo.java
+++ b/src/main/java/com/lokoko/domain/video/entity/ReviewVideo.java
@@ -1,9 +1,7 @@
 package com.lokoko.domain.video.entity;
 
-import com.lokoko.domain.image.entity.ReceiptImage;
 import com.lokoko.domain.review.entity.Review;
 import com.lokoko.global.common.entity.MediaFile;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -23,28 +21,26 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReviewVideo {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "review_video_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_video_id")
+    private Long id;
 
-	@Embedded
-	private MediaFile mediaFile; // 파일 이름, 파일 경로 포함
+    @Embedded
+    private MediaFile mediaFile; // 파일 이름, 파일 경로 포함
 
-	private int displayOrder; // 배치순서
+    private int displayOrder; // 배치순서
 
-	@ManyToOne
-	@JoinColumn(name = "review_id")
-	private Review review; // 동영상이 어떤 리뷰에 대한 것인지 (외래키)
+    @ManyToOne
+    @JoinColumn(name = "review_id")
+    private Review review; // 동영상이 어떤 리뷰에 대한 것인지 (외래키)
 
-	public static ReviewVideo createReviewVideo(String fileName,
-		String fileUrl, int displayOrder, Review review) {
-		return ReviewVideo.builder()
-			.mediaFile(MediaFile.of(fileName, fileUrl))
-			.displayOrder(displayOrder)
-			.review(review)
-			.build();
-	}
-
-
+    public static ReviewVideo createReviewVideo(String fileName,
+                                                String fileUrl, int displayOrder, Review review) {
+        return ReviewVideo.builder()
+                .mediaFile(MediaFile.of(fileName, fileUrl))
+                .displayOrder(displayOrder)
+                .review(review)
+                .build();
+    }
 }

--- a/src/main/java/com/lokoko/domain/video/entity/ReviewVideo.java
+++ b/src/main/java/com/lokoko/domain/video/entity/ReviewVideo.java
@@ -1,5 +1,7 @@
 package com.lokoko.domain.video.entity;
 
+import static jakarta.persistence.FetchType.LAZY;
+
 import com.lokoko.domain.review.entity.Review;
 import com.lokoko.global.common.entity.MediaFile;
 import jakarta.persistence.Column;
@@ -31,7 +33,7 @@ public class ReviewVideo {
 
     private int displayOrder; // 배치순서
 
-    @ManyToOne
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "review_id")
     private Review review; // 동영상이 어떤 리뷰에 대한 것인지 (외래키)
 

--- a/src/main/java/com/lokoko/domain/video/repository/ReviewVideoRepository.java
+++ b/src/main/java/com/lokoko/domain/video/repository/ReviewVideoRepository.java
@@ -1,8 +1,7 @@
 package com.lokoko.domain.video.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.lokoko.domain.video.entity.ReviewVideo;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewVideoRepository extends JpaRepository<ReviewVideo, Long> {
 }

--- a/src/main/java/com/lokoko/domain/video/repository/ReviewVideoRepository.java
+++ b/src/main/java/com/lokoko/domain/video/repository/ReviewVideoRepository.java
@@ -1,0 +1,8 @@
+package com.lokoko.domain.video.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.lokoko.domain.video.entity.ReviewVideo;
+
+public interface ReviewVideoRepository extends JpaRepository<ReviewVideo, Long> {
+}

--- a/src/main/java/com/lokoko/domain/video/repository/ReviewVideoRepository.java
+++ b/src/main/java/com/lokoko/domain/video/repository/ReviewVideoRepository.java
@@ -2,6 +2,8 @@ package com.lokoko.domain.video.repository;
 
 import com.lokoko.domain.video.entity.ReviewVideo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ReviewVideoRepository extends JpaRepository<ReviewVideo, Long> {
 }

--- a/src/main/java/com/lokoko/global/common/entity/MediaFile.java
+++ b/src/main/java/com/lokoko/global/common/entity/MediaFile.java
@@ -1,0 +1,27 @@
+package com.lokoko.global.common.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+
+public class MediaFile {
+
+	private String fileName;
+	private String fileUrl;
+
+	public MediaFile(String fileName, String fileUrl) {
+		this.fileName = fileName;
+		this.fileUrl = fileUrl;
+	}
+
+	public static MediaFile of(String fileName, String fileUrl) {
+		return new MediaFile(fileName, fileUrl);
+	}
+
+}

--- a/src/main/java/com/lokoko/global/common/entity/MediaFile.java
+++ b/src/main/java/com/lokoko/global/common/entity/MediaFile.java
@@ -2,7 +2,6 @@ package com.lokoko.global.common.entity;
 
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,16 +11,16 @@ import lombok.NoArgsConstructor;
 
 public class MediaFile {
 
-	private String fileName;
-	private String fileUrl;
+    private String fileName;
+    private String fileUrl;
 
-	public MediaFile(String fileName, String fileUrl) {
-		this.fileName = fileName;
-		this.fileUrl = fileUrl;
-	}
+    public MediaFile(String fileName, String fileUrl) {
+        this.fileName = fileName;
+        this.fileUrl = fileUrl;
+    }
 
-	public static MediaFile of(String fileName, String fileUrl) {
-		return new MediaFile(fileName, fileUrl);
-	}
+    public static MediaFile of(String fileName, String fileUrl) {
+        return new MediaFile(fileName, fileUrl);
+    }
 
 }

--- a/src/main/java/com/lokoko/global/common/entity/MediaFile.java
+++ b/src/main/java/com/lokoko/global/common/entity/MediaFile.java
@@ -2,13 +2,14 @@ package com.lokoko.global.common.entity;
 
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-
+@EqualsAndHashCode
 public class MediaFile {
 
     private String fileName;


### PR DESCRIPTION
## Related issue 🛠

- closed #14 

## 작업 내용 💻

- [리뷰 엔티티 구현 ] 
- [리뷰 이미지 엔티티 구현] 
- [영수증 이미지 엔티티 구현]
- [리뷰 좋아요 엔티티 구현]
- [리뷰 동영상 엔티티 구현]
- [위 엔티티에 대응하는 레포지토리 생성]

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

이미지 , 동영상 엔티티에 "파일 이름, 파일 경로" 같은 필드가 반복해서 나타났습니다.
이 값들을 일일이 적어주기 보다는, 위 필드들을 가지고 있는 MediaFile 이라는 값 타입 객체를 두어서 반복되는 코드를 제거해주었습니다.

1. Review 엔티티 필드에 likeCount 를 두는 것이 적합한 것인가?
2. code rabbit 이 제시해준 것 처럼 BaseReviewMedia 를 만들어주는 것이 좋을까?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
    - 리뷰에 이미지, 영수증 이미지, 비디오를 첨부할 수 있는 기능이 추가되었습니다.
    - 리뷰에 ‘좋아요’를 남길 수 있는 기능이 추가되었습니다.
    - 리뷰 작성 시 긍정/부정 내용을 입력할 수 있으며, 이후 수정도 가능합니다.

- **기타**
    - 미디어 파일(이미지/비디오) 정보를 효율적으로 관리하기 위한 구조가 도입되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->