### PR TITLE
[Feat] #25 인기 k 뷰티 유튜브 영상 크롤링

### DIFF
--- a/src/main/java/com/lokoko/domain/product/controller/ProductController.java
+++ b/src/main/java/com/lokoko/domain/product/controller/ProductController.java
@@ -24,6 +24,6 @@ public class ProductController {
     public ApiResponse<Void> crawl(@RequestBody CrawlRequest request) {
         productCrawlingService.scrapeByCategory(request.mainCategory(), request.middleCategory());
 
-        return ApiResponse.success(HttpStatus.OK, ResponseMessage.CRAWL_SUCCESS.getMessage(), null);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.PRODUCT_CRAWL_SUCCESS.getMessage(), null);
     }
 }

--- a/src/main/java/com/lokoko/domain/product/controller/enums/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/product/controller/enums/ResponseMessage.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ResponseMessage {
-    CRAWL_SUCCESS("상품 크롤링에 성공했습니다.");
+    PRODUCT_CRAWL_SUCCESS("상품 크롤링에 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/video/entity/YoutubeVideo.java
+++ b/src/main/java/com/lokoko/domain/video/entity/YoutubeVideo.java
@@ -52,4 +52,8 @@ public class YoutubeVideo extends BaseEntity {
         video.uploadedAt = uploadedAt;
         return video;
     }
+
+    public void updatePopularity(Integer popularity) {
+        this.popularity = popularity;
+    }
 }

--- a/src/main/java/com/lokoko/domain/video/entity/YoutubeVideo.java
+++ b/src/main/java/com/lokoko/domain/video/entity/YoutubeVideo.java
@@ -1,0 +1,55 @@
+package com.lokoko.domain.video.entity;
+
+import com.lokoko.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class YoutubeVideo extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "youtube_video_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String topic;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String url;
+
+    @Column(nullable = false)
+    private Long viewCount;
+
+    @Column(nullable = false)
+    private Integer popularity;
+
+    @Column
+    private LocalDateTime uploadedAt;
+
+    public static YoutubeVideo of(String topic, String title, String url, Integer popularity, Long viewCount,
+                                  LocalDateTime uploadedAt) {
+        YoutubeVideo video = new YoutubeVideo();
+        video.topic = topic;
+        video.title = title;
+        video.url = url;
+        video.popularity = popularity;
+        video.viewCount = viewCount;
+        video.uploadedAt = uploadedAt;
+        return video;
+    }
+}

--- a/src/main/java/com/lokoko/domain/youtube/controller/YoutubeController.java
+++ b/src/main/java/com/lokoko/domain/youtube/controller/YoutubeController.java
@@ -1,30 +1,53 @@
 package com.lokoko.domain.youtube.controller;
 
-import com.lokoko.domain.product.controller.enums.ResponseMessage;
 import com.lokoko.domain.product.dto.CrawlResponse;
-import com.lokoko.domain.youtube.service.YoutubeCrawlerService;
+import com.lokoko.domain.youtube.controller.enums.ResponseMessage;
+import com.lokoko.domain.youtube.dto.VideoResponse;
+import com.lokoko.domain.youtube.service.YoutubeReviewCrawler;
+import com.lokoko.domain.youtube.service.YoutubeTrendService;
 import com.lokoko.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "YOUTUBE")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/youtube")
 public class YoutubeController {
-    private final YoutubeCrawlerService youtubeCrawlerService;
+    private final YoutubeReviewCrawler youtubeReviewCrawler;
+    private final YoutubeTrendService youtubeTrendService;
 
     @Hidden
+    @Operation(summary = "유튜브 리뷰 크롤링 (SERVER ONLY)")
     @PostMapping("/{productId}/crawl")
     public ApiResponse<CrawlResponse> crawl(@PathVariable Long productId) {
-        List<String> videoUrls = youtubeCrawlerService.crawlAndStoreReviews(productId);
+        List<String> videoUrls = youtubeReviewCrawler.crawlAndStoreReviews(productId);
 
-        return ApiResponse.success(HttpStatus.OK, ResponseMessage.CRAWL_SUCCESS.getMessage(),
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.REVIEW_CRAWL_SUCCESS.getMessage(),
                 CrawlResponse.of(videoUrls));
+    }
+
+    @Hidden
+    @Operation(summary = "인기 뷰티 트렌드 영상 크롤링 (SERVER ONLY)")
+    @PostMapping("/trends/crawl")
+    public ApiResponse<Void> crawlPopularTrends() {
+        youtubeTrendService.crawlPopularBeautyVideos();
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.POPULAR_TRENDS_CRAWL_SUCCESS.getMessage());
+    }
+
+    @Operation(summary = "인기 뷰티 트렌드 영상 조회")
+    @GetMapping("/trends")
+    public ApiResponse<List<VideoResponse>> getPopularTrends() {
+        List<VideoResponse> videos = youtubeTrendService.findAll();
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.POPULAR_TRENDS_GET_SUCCESS.getMessage(), videos);
     }
 }

--- a/src/main/java/com/lokoko/domain/youtube/controller/enums/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/youtube/controller/enums/ResponseMessage.java
@@ -1,0 +1,15 @@
+package com.lokoko.domain.youtube.controller.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+    REVIEW_CRAWL_SUCCESS("유튜브 리뷰영상 크롤링에 성공했습니다."),
+    POPULAR_TRENDS_CRAWL_SUCCESS("인기 뷰티 트렌드 영상 크롤링에 성공했습니다."),
+
+    POPULAR_TRENDS_GET_SUCCESS("인기 뷰티 트렌드 영상 조회에 성공했습니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/lokoko/domain/youtube/dto/VideoResponse.java
+++ b/src/main/java/com/lokoko/domain/youtube/dto/VideoResponse.java
@@ -1,0 +1,26 @@
+package com.lokoko.domain.youtube.dto;
+
+import com.lokoko.domain.video.entity.YoutubeVideo;
+import java.time.LocalDateTime;
+
+public record VideoResponse(
+        Long id,
+        String topic,
+        String title,
+        String url,
+        Integer popularity,
+        Long viewCount,
+        LocalDateTime uploadedAt
+) {
+    public static VideoResponse from(YoutubeVideo video) {
+        return new VideoResponse(
+                video.getId(),
+                video.getTopic(),
+                video.getTitle(),
+                video.getUrl(),
+                video.getPopularity(),
+                video.getViewCount(),
+                video.getUploadedAt()
+        );
+    }
+}

--- a/src/main/java/com/lokoko/domain/youtube/exception/YoutubeApiException.java
+++ b/src/main/java/com/lokoko/domain/youtube/exception/YoutubeApiException.java
@@ -4,7 +4,7 @@ import com.lokoko.global.common.exception.BaseException;
 import org.springframework.http.HttpStatus;
 
 public class YoutubeApiException extends BaseException {
-    public YoutubeApiException(ErrorMessage errorMessage) {
-        super(HttpStatus.BAD_GATEWAY, errorMessage.getMessage());
+    public YoutubeApiException() {
+        super(HttpStatus.BAD_GATEWAY, ErrorMessage.YOUTUBE_API_CALL_FAILED.getMessage());
     }
 }

--- a/src/main/java/com/lokoko/domain/youtube/repository/YoutubeVideoRepository.java
+++ b/src/main/java/com/lokoko/domain/youtube/repository/YoutubeVideoRepository.java
@@ -1,0 +1,10 @@
+package com.lokoko.domain.youtube.repository;
+
+import com.lokoko.domain.video.entity.YoutubeVideo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface YoutubeVideoRepository extends JpaRepository<YoutubeVideo, Long> {
+    
+}

--- a/src/main/java/com/lokoko/domain/youtube/service/PopularVideoCrawler.java
+++ b/src/main/java/com/lokoko/domain/youtube/service/PopularVideoCrawler.java
@@ -1,0 +1,86 @@
+package com.lokoko.domain.youtube.service;
+
+import com.google.api.services.youtube.YouTube;
+import com.lokoko.domain.video.entity.YoutubeVideo;
+import com.lokoko.domain.youtube.exception.YoutubeApiException;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PopularVideoCrawler {
+
+    private final YouTube youtube;
+    private final String apiKey;
+
+    public List<YoutubeVideo> crawl(List<String> topics) {
+        List<YoutubeVideo> result = new ArrayList<>();
+
+        for (String topic : topics) {
+            try {
+                List<String> ids = searchVideoIds(topic);
+                log.info("Topic='{}' 검색된 영상 ID 수={}", topic, ids.size());
+                result.addAll(fetchVideoDetails(topic, ids));
+            } catch (IOException e) {
+                log.error("유튜브 API 에러 ({}): {}", topic, e.getMessage(), e);
+                throw new YoutubeApiException();
+            }
+        }
+        log.info("크롤러 전체 결과 개수={}", result.size());
+        return result;
+    }
+
+    private List<String> searchVideoIds(String topic) throws IOException {
+        YouTube.Search.List search = youtube.search().list(List.of("id"));
+        search.setKey(apiKey)
+                .setQ(topic)
+                .setType(List.of("video"))
+                .setOrder("viewCount")
+                .setPublishedAfter("2024-01-01T00:00:00Z")
+                .setMaxResults(10L);
+
+        return search.execute()
+                .getItems()
+                .stream()
+                .map(item -> item.getId().getVideoId())
+                .toList();
+    }
+
+    private List<YoutubeVideo> fetchVideoDetails(String topic, List<String> ids) throws IOException {
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+
+        YouTube.Videos.List list = youtube.videos()
+                .list(List.of("snippet", "statistics"));
+
+        list.setKey(apiKey)
+                .setId(ids);
+
+        return list.execute()
+                .getItems()
+                .stream()
+                .map(item -> {
+                    Instant instant = Instant.ofEpochMilli(item.getSnippet().getPublishedAt().getValue());
+                    LocalDateTime uploadedAt = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+
+                    return YoutubeVideo.of(
+                            topic,
+                            item.getSnippet().getTitle(),
+                            "https://www.youtube.com/watch?v=" + item.getId(),
+                            item.getStatistics().getViewCount().intValue(),
+                            item.getStatistics().getViewCount().longValue(),
+                            uploadedAt
+                    );
+                })
+                .toList();
+    }
+}

--- a/src/main/java/com/lokoko/domain/youtube/service/PopularVideoCrawler.java
+++ b/src/main/java/com/lokoko/domain/youtube/service/PopularVideoCrawler.java
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class PopularVideoCrawler {
-
     private final YouTube youtube;
     private final String apiKey;
 
@@ -27,14 +26,12 @@ public class PopularVideoCrawler {
         for (String topic : topics) {
             try {
                 List<String> ids = searchVideoIds(topic);
-                log.info("Topic='{}' 검색된 영상 ID 수={}", topic, ids.size());
                 result.addAll(fetchVideoDetails(topic, ids));
             } catch (IOException e) {
                 log.error("유튜브 API 에러 ({}): {}", topic, e.getMessage(), e);
                 throw new YoutubeApiException();
             }
         }
-        log.info("크롤러 전체 결과 개수={}", result.size());
         return result;
     }
 

--- a/src/main/java/com/lokoko/domain/youtube/service/VideoSaveService.java
+++ b/src/main/java/com/lokoko/domain/youtube/service/VideoSaveService.java
@@ -1,0 +1,24 @@
+package com.lokoko.domain.youtube.service;
+
+import com.lokoko.domain.video.entity.YoutubeVideo;
+import com.lokoko.domain.youtube.repository.YoutubeVideoRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VideoSaveService {
+    private final YoutubeVideoRepository repository;
+
+    @Transactional
+    public void replaceAll(List<YoutubeVideo> videos) {
+        log.info("기존 영상 {}개 삭제 시작", repository.count());
+        repository.deleteAll();
+        log.info("삭제 완료, 새로 저장할 개수={}", videos.size());
+        repository.saveAll(videos);
+    }
+}

--- a/src/main/java/com/lokoko/domain/youtube/service/YoutubeReviewCrawler.java
+++ b/src/main/java/com/lokoko/domain/youtube/service/YoutubeReviewCrawler.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class YoutubeCrawlerService {
+public class YoutubeReviewCrawler {
     private final YoutubeApiService youtubeApiService;
     private final ProductRepository productRepository;
 

--- a/src/main/java/com/lokoko/domain/youtube/service/YoutubeTrendService.java
+++ b/src/main/java/com/lokoko/domain/youtube/service/YoutubeTrendService.java
@@ -1,0 +1,61 @@
+package com.lokoko.domain.youtube.service;
+
+import com.lokoko.domain.video.entity.YoutubeVideo;
+import com.lokoko.domain.youtube.dto.VideoResponse;
+import com.lokoko.domain.youtube.repository.YoutubeVideoRepository;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class YoutubeTrendService {
+    private static final List<String> BEAUTY_TOPICS = List.of(
+            "2025 여름 메이크업 트렌드",
+            "10단계 스킨케어 루틴",
+            "인기 K-뷰티 신제품",
+            "여드름 피부 커버 메이크업",
+            "지성 피부 파운데이션 추천",
+            "아이크림 효과 비교",
+            "선크림 중요성 및 사용법",
+            "화이트닝 미백 크림 추천",
+            "수분 부족 피부 관리법",
+            "민감성 피부 케어 방법"
+    );
+    private final PopularVideoCrawler crawlService;
+    private final VideoSaveService saveService;
+    private final YoutubeVideoRepository repository;
+
+    @Transactional
+    public void crawlPopularBeautyVideos() {
+        List<YoutubeVideo> allVideos = crawlService.crawl(BEAUTY_TOPICS);
+        allVideos.sort(Comparator.comparingLong(YoutubeVideo::getViewCount).reversed());
+
+        List<YoutubeVideo> top10Unique = new ArrayList<>();
+        Set<String> seenUrls = new HashSet<>();
+
+        for (YoutubeVideo video : allVideos) {
+            if (seenUrls.add(video.getUrl())) {
+                top10Unique.add(video);
+            }
+            if (top10Unique.size() == 10) {
+                break;
+            }
+        }
+
+        saveService.replaceAll(top10Unique);
+    }
+
+    public List<VideoResponse> findAll() {
+        return repository.findAll()
+                .stream()
+                .map(VideoResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/lokoko/domain/youtube/service/YoutubeTrendService.java
+++ b/src/main/java/com/lokoko/domain/youtube/service/YoutubeTrendService.java
@@ -48,6 +48,9 @@ public class YoutubeTrendService {
                 break;
             }
         }
+        for (int i = 0; i < top10Unique.size(); i++) {
+            top10Unique.get(i).updatePopularity(i + 1);
+        }
 
         saveService.replaceAll(top10Unique);
     }

--- a/src/main/java/com/lokoko/global/auth/controller/AuthController.java
+++ b/src/main/java/com/lokoko/global/auth/controller/AuthController.java
@@ -8,6 +8,8 @@ import com.lokoko.global.auth.line.dto.LineLoginResponse;
 import com.lokoko.global.auth.line.dto.LoginUrlResponse;
 import com.lokoko.global.auth.service.AuthService;
 import com.lokoko.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,12 +17,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "AUTH")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
     private final AuthService authService;
 
+    @Operation(summary = "라인 소셜 로그인, JWT 토큰 발급")
     @GetMapping("/line/login")
     public ApiResponse<LineLoginResponse> lineLogin(@RequestParam("code") String code) {
         JwtTokenDto tokens = authService.loginWithLine(code);
@@ -28,6 +32,7 @@ public class AuthController {
         return ApiResponse.success(HttpStatus.OK, LOGIN_SUCCESS.getMessage(), new LineLoginResponse(tokens));
     }
 
+    @Operation(summary = "라인 로그인 URL 생성 (클라에서 호출)")
     @GetMapping("/url")
     public ApiResponse<LoginUrlResponse> getLoginUrl() {
         String url = authService.generateLineLoginUrl();

--- a/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
@@ -15,7 +15,6 @@ public class PermitUrlConfig {
 
     public String[] getUserUrl() {
         return new String[]{
-                "/api/youtubes/**"
         };
     }
 
@@ -23,6 +22,8 @@ public class PermitUrlConfig {
         return new String[]{
                 "/api/admin/**",
                 "/api/products/crawl",
+                "/api/youtube/{productId}/crawl",
+                "/api/youtube/trends/crawl"
         };
     }
 


### PR DESCRIPTION
## Related issue 🛠

- closed #24 

## 작업 내용 💻

- [x] 이전 브랜치에서 머지한 YouTube Data API v3 이용해서 유튜브 서비스 구현
- [x] K-뷰티 영상을 인기순으로, 2025년에 올라온 인기 영상 크롤러 구현
- [x] 메인페이지 인기 K-뷰티 유튜브 영상 구현

## 스크린샷 📷

![image](https://github.com/user-attachments/assets/f5e58a88-c6d2-4808-81dd-f2bf9109aab0)
![image](https://github.com/user-attachments/assets/f565ffb2-7616-45e3-aebb-22a7051bfc04)


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- 컨트롤러에 @Operation이랑 @Tag 어노테이션 확인해주시고, 컨벤션처럼 각자 도메인 개발할때 참고해주시면 될거같습니다 !

