### PR TITLE
Feat #30 신제품 크롤링 api 구현

### DIFF
--- a/src/main/java/com/lokoko/domain/product/controller/ProductController.java
+++ b/src/main/java/com/lokoko/domain/product/controller/ProductController.java
@@ -3,6 +3,7 @@ package com.lokoko.domain.product.controller;
 
 import com.lokoko.domain.product.controller.enums.ResponseMessage;
 import com.lokoko.domain.product.dto.CrawlRequest;
+import com.lokoko.domain.product.service.NewProductCrawlingService;
 import com.lokoko.domain.product.service.ProductCrawlingService;
 import com.lokoko.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Hidden;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ProductController {
     private final ProductCrawlingService productCrawlingService;
+    private final NewProductCrawlingService newProductCrawlingService;
 
     @Hidden
     @PostMapping("/crawl")
@@ -25,5 +27,12 @@ public class ProductController {
         productCrawlingService.scrapeByCategory(request.mainCategory(), request.middleCategory());
 
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.PRODUCT_CRAWL_SUCCESS.getMessage(), null);
+    }
+
+    @Hidden
+    @PostMapping("/crawl/new")
+    public ApiResponse<Void> crawlNew(@RequestBody CrawlRequest request) {
+        newProductCrawlingService.scrapeNewByCategory(request.mainCategory(), request.middleCategory());
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.PRODUCT_CRAWL_NEW_SUCCESS.getMessage(), null);
     }
 }

--- a/src/main/java/com/lokoko/domain/product/controller/enums/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/product/controller/enums/ResponseMessage.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ResponseMessage {
-    PRODUCT_CRAWL_SUCCESS("상품 크롤링에 성공했습니다.");
+    PRODUCT_CRAWL_SUCCESS("상품 크롤링에 성공했습니다."),
+    PRODUCT_CRAWL_NEW_SUCCESS("신상품 크롤링에 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/product/service/NewProductCrawlingService.java
+++ b/src/main/java/com/lokoko/domain/product/service/NewProductCrawlingService.java
@@ -1,0 +1,196 @@
+package com.lokoko.domain.product.service;
+
+import com.lokoko.domain.image.entity.ProductImage;
+import com.lokoko.domain.image.repository.ProductImageRepository;
+import com.lokoko.domain.product.entity.Product;
+import com.lokoko.domain.product.entity.enums.MainCategory;
+import com.lokoko.domain.product.entity.enums.MiddleCategory;
+import com.lokoko.domain.product.entity.enums.SubCategory;
+import com.lokoko.domain.product.entity.enums.Tag;
+import com.lokoko.domain.product.repository.ProductRepository;
+import com.lokoko.global.utils.ProductCrawlerConstants;
+import com.lokoko.global.utils.ProductCrawlerUtil;
+import java.time.Duration;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NewProductCrawlingService {
+    private static final int MAX_PER_SUB = 5;
+
+    private final WebDriver driver;
+    private final ProductRepository productRepository;
+    private final ProductImageRepository productImageRepository;
+    private final ShoppingPreferenceManager preferenceManager;
+    private final ProductCrawlerUtil util;
+
+    @Transactional
+    public void scrapeNewByCategory(MainCategory main, MiddleCategory middle) {
+        preferenceManager.ensureJapanCountry();
+        List<SubCategory> subs = List.of(SubCategory.values());
+        subs.stream()
+                .filter(sc -> sc.getMiddleCategory() == middle)
+                .forEach(sub -> scrapeNewBySub(main, middle, sub));
+    }
+
+    private void scrapeNewBySub(MainCategory main,
+                                MiddleCategory middle,
+                                SubCategory sub) {
+        JavascriptExecutor js = (JavascriptExecutor) driver;
+        try {
+            String url = String.format(
+                    ProductCrawlerConstants.BASE_URL +
+                            ProductCrawlerConstants.PATH_DISPLAY_CATEGORY,
+                    middle.getCtgrNo()
+            );
+            driver.get(url);
+
+            util.waitForPresence(ProductCrawlerConstants.SELECTOR_WRAP_LNB_FILTER, 20);
+            util.clearOtherSubCategories(middle, sub, js);
+            util.selectTargetSubCategory(sub, js);
+            util.safeSleep(ProductCrawlerConstants.DEFAULT_SLEEP_AFTER_FILTER_MS);
+
+            clickSortOption(js, "20");
+            waitForSortApplied(ProductCrawlerConstants.TAG_TEXT_NEW, 20);
+
+            util.waitForNonEmpty(
+                    ProductCrawlerConstants.SELECTOR_CATEGORY_PRODUCT_LIST_ITEM, 25
+            );
+            util.safeSleep(3_000);
+
+            List<String> detailUrls = driver.findElements(
+                            By.cssSelector(ProductCrawlerConstants.SELECTOR_CATEGORY_PRODUCT_LIST_LINK)
+                    )
+                    .stream()
+                    .map(a -> a.getAttribute("href"))
+                    .filter(h -> h != null && h.contains("prdtNo="))
+                    .map(h -> h.startsWith("http")
+                            ? h
+                            : ProductCrawlerConstants.BASE_URL + h)
+                    .distinct()
+                    .toList();
+
+            int saved = 0;
+            for (String detailUrl : detailUrls) {
+                if (saved >= MAX_PER_SUB) {
+                    break;
+                }
+                if (scrapeNewDetailPageSafelyInNewTab(
+                        detailUrl, main, middle, sub
+                )) {
+                    saved++;
+                }
+                util.safeSleep(ProductCrawlerConstants.SHORT_WAIT_SEC);
+            }
+
+        } catch (Exception e) {
+            log.error("신제품 크롤링 실패: {} > {} > {}", main, middle, sub, e);
+        }
+    }
+
+    private boolean scrapeNewDetailPageSafelyInNewTab(String url,
+                                                      MainCategory main, MiddleCategory middle, SubCategory sub) {
+
+        String originalTab = util.openNewTabAndSwitch();
+        try {
+            driver.get(url);
+            util.waitForPresence(ProductCrawlerConstants.SELECTOR_PRICE_INFO, 20);
+            util.safeSleep(2_000);
+
+            long price = util.extractPrice();
+            String ship = util.safeText(By.cssSelector(".prd-delivery-info"));
+            String brand = util.safeText(By.cssSelector(".prd-brand-info h3"));
+            String detail = util.safeText(By.cssSelector(".prd-brand-info dl"));
+            Tag tag = util.extractTag();
+            String productDetail = util.expandAndExtract(
+                    ProductCrawlerConstants.SELECTORS_PRODUCT_DETAIL, "#agreeList1"
+            );
+            String ingredients = util.expandAndExtract(
+                    ProductCrawlerConstants.SELECTORS_INGREDIENTS, "#agreeList2"
+            );
+            if ((productDetail == null && ingredients == null)
+                    || brand == null || detail == null) {
+                return false;
+            }
+
+            Product p = Product.builder()
+                    .normalPrice(price)
+                    .brandName(brand)
+                    .productName(detail)
+                    .shippingInfo(ship != null ? ship : "배송 정보 없음")
+                    .tag(tag)
+                    .mainCategory(main)
+                    .middleCategory(middle)
+                    .subCategory(sub)
+                    .productDetail(productDetail)
+                    .ingredients(ingredients)
+                    .oliveYoungUrl(url)
+                    .build();
+
+            Product saved = productRepository.save(p);
+            util.extractImageUrl().ifPresent(imgUrl ->
+                    productImageRepository.save(
+                            ProductImage.builder()
+                                    .product(saved)
+                                    .url(imgUrl)
+                                    .build()
+                    )
+            );
+            return true;
+        } catch (Exception e) {
+            log.error("신제품 상세 페이지 크롤링 오류 (URL={}): {}", url, e.getMessage());
+            return false;
+        } finally {
+            util.closeCurrentTabAndSwitchBack(originalTab);
+        }
+    }
+
+    private void clickSortOption(JavascriptExecutor js, String sortValue) {
+        try {
+            WebElement sortButton = driver.findElement(By.id("prdtSortStdrCode"));
+            String beforeText = sortButton.getText();
+            util.scrollAndClick(sortButton);
+            util.safeSleep(500);
+
+            By optionListLocator = By.cssSelector("ul.sort-list");
+            WebElement optionList = util.waitForElementVisible(optionListLocator, 5);
+            List<WebElement> options = optionList.findElements(By.tagName("li"));
+
+            for (WebElement opt : options) {
+                if (sortValue.equals(opt.getAttribute("value"))) {
+                    util.scrollAndClick(opt);
+                    util.safeSleep(1000);
+
+                    String afterText = driver.findElement(By.id("prdtSortStdrCode")).getText();
+                    log.info("정렬 변경: {} → {}", beforeText, afterText);
+                    return;
+                }
+            }
+            log.warn("정렬 옵션 미발견: value={}", sortValue);
+        } catch (Exception e) {
+            log.error("정렬 처리 실패: {}", e.getMessage());
+        }
+    }
+
+    private void waitForSortApplied(String expectedText, int timeoutSec) {
+        new WebDriverWait(driver, Duration.ofSeconds(timeoutSec))
+                .until((WebDriver d) -> {
+                    try {
+                        WebElement sortBtn = d.findElement(By.id("prdtSortStdrCode"));
+                        return sortBtn.getText().contains(expectedText);
+                    } catch (Exception e) {
+                        return false;
+                    }
+                });
+    }
+}

--- a/src/main/java/com/lokoko/domain/review/entity/Review.java
+++ b/src/main/java/com/lokoko/domain/review/entity/Review.java
@@ -39,10 +39,13 @@ public class Review extends BaseEntity {
     @JoinColumn(name = "product_id")
     private Product product;
 
+    @Column(nullable = false, length = 500)
     private String positiveContent; // 긍정 리뷰 내용
 
+    @Column(nullable = false, length = 500)
     private String negativeContent; // 부정 리뷰 내용
 
+    @Column(nullable = false)
     private int likeCount; // 좋아요 수
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/lokoko/domain/review/entity/Review.java
+++ b/src/main/java/com/lokoko/domain/review/entity/Review.java
@@ -2,10 +2,14 @@ package com.lokoko.domain.review.entity;
 
 import static jakarta.persistence.FetchType.LAZY;
 
+import com.lokoko.domain.product.entity.Product;
+import com.lokoko.domain.review.entity.enums.Rating;
 import com.lokoko.domain.user.entity.User;
 import com.lokoko.global.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -31,16 +35,19 @@ public class Review extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User author; // 리뷰 작성자 foreign key 매핑
 
-    // Product 엔티티가 만들어지고 난 후, 주석 해제 해야합니다.
-    // @ManyToOne
-    // @JoinColumn(name = "product_id")
-    // private Product product;
+    @ManyToOne
+    @JoinColumn(name = "product_id")
+    private Product product;
 
     private String positiveContent; // 긍정 리뷰 내용
 
     private String negativeContent; // 부정 리뷰 내용
 
     private int likeCount; // 좋아요 수
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 5)
+    private Rating rating;
 
     public static Review createReview(User user, String positive, String negative) {
         return Review.builder()

--- a/src/main/java/com/lokoko/domain/review/entity/enums/Rating.java
+++ b/src/main/java/com/lokoko/domain/review/entity/enums/Rating.java
@@ -1,0 +1,16 @@
+package com.lokoko.domain.review.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Rating {
+    ONE("1"),
+    TWO("2"),
+    THREE("3"),
+    FOUR("4"),
+    FIVE("5");
+
+    private final String value;
+}

--- a/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
@@ -23,7 +23,9 @@ public class PermitUrlConfig {
                 "/api/admin/**",
                 "/api/products/crawl",
                 "/api/youtube/{productId}/crawl",
-                "/api/youtube/trends/crawl"
+                "/api/youtube/trends/crawl",
+                "/api/products/crawl/",
+                "/api/products/crawl/new",
         };
     }
 

--- a/src/main/java/com/lokoko/global/utils/ProductCrawlerConstants.java
+++ b/src/main/java/com/lokoko/global/utils/ProductCrawlerConstants.java
@@ -5,7 +5,7 @@ public final class ProductCrawlerConstants {
     public static final String BASE_URL = "https://global.oliveyoung.com";
     public static final String PATH_DISPLAY_CATEGORY = "/display/category?ctgrNo=%s";
 
-    // Selectors
+    // 필터
     public static final String SELECTOR_WRAP_LNB_FILTER = ".wrap-lnb-filter";
     public static final String[] SELECTORS_SUBCATEGORY_AREA = {
             "ul.depth-3",
@@ -15,45 +15,45 @@ public final class ProductCrawlerConstants {
     public static final String SELECTOR_INPUT_SUBCATEGORY_FORMAT = "input[data-item_no='%s']";
     public static final String SELECTOR_LABEL_SUBCATEGORY_FORMAT = "label[for='%s']";
     public static final String SELECTOR_FILTER_TAG_FORMAT = "div.filter-tag span.tag[data-item_no='%s']";
+
+    // 상품 리스트 (최신·신제품 공통)
     public static final String SELECTOR_CATEGORY_PRODUCT_LIST_LINK = "#categoryProductList li div.unit-thumb a";
     public static final String SELECTOR_CATEGORY_PRODUCT_LIST_ITEM = "#categoryProductList li";
+
+    // 태그 뱃지
     public static final String SELECTOR_TAG_BADGE = ".prd-bedge";
     public static final String TAG_TEXT_BEST = "베스트";
     public static final String TAG_TEXT_NEW = "신상품";
+
+    // 이미지
     public static final String SELECTOR_ZOOM_IMAGE = ".prd-visual-content .prd-unit-img img#zoom_01";
     public static final String SELECTOR_ANY_IMAGE = ".prd-visual-content .prd-unit-img img";
     public static final String SELECTOR_IMAGE_SLIDE = ".prd-visual-content .swiper-slide";
+
+    // 상세페이지
     public static final String SELECTOR_PRICE_INFO = ".prd-price-info";
     public static final String SELECTOR_PRICE_NORMAL = ".prd-price-info .price span";
     public static final String SELECTOR_PRICE_SALE = ".prd-price-info dd.sale-price";
     public static final String REGEX_YEN = "¥[0-9,]+";
-
-    // Error messages
-    public static final String ERROR_MSG_EXTRACT_ID = "Error extracting product ID from URL: ";
-    public static final String ERROR_MSG_PARSE_PRICE = "Failed to parse price: ";
-    public static final String ERROR_MSG_SLEEP_INTERRUPTED = "Sleep interrupted: ";
-
-    // Selectors
     public static final String[] SELECTORS_PRODUCT_DETAIL = {
-            "a[href='#agreeList1']",
-            "a[data-target='#agreeList1']",
-            "a:contains('商品特徴')",
-            "a:contains('상세')",
-            "a:contains('특징')"
+            "a[href='#agreeList1']", "a[data-target='#agreeList1']",
+            "a:contains('商品特徴')", "a:contains('상세')", "a:contains('특징')"
     };
     public static final String[] SELECTORS_INGREDIENTS = {
-            "a[href='#agreeList2']",
-            "a[data-target='#agreeList2']",
-            "a:contains('原材料')",
-            "a:contains('성분')",
-            "a:contains('원료')"
+            "a[href='#agreeList2']", "a[data-target='#agreeList2']",
+            "a:contains('原材料')", "a:contains('성분')", "a:contains('원료')"
     };
 
-    // Sleep durations
+    // 공통 대기·슬립
     public static final long SAFETY_SLEEP_MS = 300L;
     public static final long DEFAULT_SLEEP_AFTER_FILTER_MS = 2000L;
     public static final long DEFAULT_WAIT_SEC = 15L;
     public static final long SHORT_WAIT_SEC = 5L;
+
+    // 에러 메시지
+    public static final String ERROR_MSG_EXTRACT_ID = "Error extracting product ID from URL: ";
+    public static final String ERROR_MSG_PARSE_PRICE = "Failed to parse price: ";
+    public static final String ERROR_MSG_SLEEP_INTERRUPTED = "Sleep interrupted: ";
 
     private ProductCrawlerConstants() {
     }


### PR DESCRIPTION
## Related issue 🛠

- closed #27 

## 작업 내용 💻

- [x] 올리브영에서 신제품 (NEW) 크롤링
- [x] 신제품 카테고리별 조회 API 구현

## 스크린샷 📷

![image](https://github.com/user-attachments/assets/b797e919-6123-4623-a79c-066535edad63)

사진은 상품 데이터 일부라서 형식만 참고해주시면 좋을거같아요

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- 세부 카테고리 당 5개씩, 총 65개의 상품 데이터 추가로 크롤링 해왔습니다. 총 데이터베이스 상품 개수는 130이라고 생각해주시면 되고,
상품 `Tag`를 `new`로 설정해서, 추후 신제품 조회 `API`에서 `new` 태그에 해당하는 상품 데이터만 크롤링 해올 예정입니다

