### PR TITLE
[FEAT] #39 상품명 / 브랜드명 상품 검색 API 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,10 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // Lucene Kuromoji – 일본어 형태소 분석기
+    runtimeOnly 'org.apache.lucene:lucene-analysis-kuromoji:10.2.2'
+    implementation "org.apache.lucene:lucene-analysis-kuromoji:10.2.2"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/lokoko/domain/product/controller/ProductController.java
+++ b/src/main/java/com/lokoko/domain/product/controller/ProductController.java
@@ -6,6 +6,7 @@ import static com.lokoko.domain.product.controller.enums.ResponseMessage.CATEGOR
 import com.lokoko.domain.product.controller.enums.ResponseMessage;
 import com.lokoko.domain.product.dto.CategoryProductResponse;
 import com.lokoko.domain.product.dto.CrawlRequest;
+import com.lokoko.domain.product.dto.NameBrandProductResponse;
 import com.lokoko.domain.product.service.NewProductCrawlingService;
 import com.lokoko.domain.product.service.ProductCrawlingService;
 import com.lokoko.domain.product.service.ProductService;
@@ -68,5 +69,14 @@ public class ProductController {
     public ApiResponse<Void> crawlOptions() {
         productCrawlingService.crawlAllOptions();
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.PRODUCT_OPTION_SUCCESS.getMessage(), null);
+    }
+
+    @Operation(summary = "상품명 또는 브랜드명 상품 검색")
+    @GetMapping("/search")
+    public ApiResponse<NameBrandProductResponse> search(@RequestParam String keyword) {
+        NameBrandProductResponse searchResults = productService.search(keyword);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.NAME_BRAND_SEARCH_SUCCESS.getMessage(),
+                searchResults);
+        
     }
 }

--- a/src/main/java/com/lokoko/domain/product/controller/enums/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/product/controller/enums/ResponseMessage.java
@@ -10,7 +10,8 @@ public enum ResponseMessage {
     CATEGORY_SEARCH_SUCCESS("카테고리 별 제품 검색에 성공했습니다."),
     CATEGORY_LIST_SUCCESS("카테고리 리스트 반환에 성공했습니다."),
     PRODUCT_CRAWL_NEW_SUCCESS("신상품 크롤링에 성공했습니다."),
-    PRODUCT_OPTION_SUCCESS("상품 옵션 크롤링에 성공했습니다.");
+    PRODUCT_OPTION_SUCCESS("상품 옵션 크롤링에 성공했습니다."),
+    NAME_BRAND_SEARCH_SUCCESS("상품명 / 브랜드명 제품 검색에 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/product/dto/NameBrandProductResponse.java
+++ b/src/main/java/com/lokoko/domain/product/dto/NameBrandProductResponse.java
@@ -1,0 +1,10 @@
+package com.lokoko.domain.product.dto;
+
+import java.util.List;
+
+public record NameBrandProductResponse(
+        String searchQuery,
+        int resultCount,
+        List<ProductResponse> products
+) {
+}

--- a/src/main/java/com/lokoko/domain/product/entity/Product.java
+++ b/src/main/java/com/lokoko/domain/product/entity/Product.java
@@ -77,7 +77,16 @@ public class Product extends BaseEntity {
     @Column(nullable = false, length = 30)
     private SubCategory subCategory;
 
+    private String searchToken;
+
+
     public void updateYoutubeUrls(List<String> urls) {
         this.youtubeUrl = String.join(",", urls);
     }
+
+    public void updateSearchToken(String join) {
+        this.searchToken = join;
+    }
+
+
 }

--- a/src/main/java/com/lokoko/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/lokoko/domain/product/repository/ProductRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ProductRepository extends JpaRepository<Product, Long> {
+public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
     long countByMainCategoryAndMiddleCategoryAndSubCategory(MainCategory mainCategory, MiddleCategory middleCategory,
                                                             SubCategory subCategory);
 

--- a/src/main/java/com/lokoko/domain/product/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/lokoko/domain/product/repository/ProductRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.lokoko.domain.product.repository;
+
+import com.lokoko.domain.product.entity.Product;
+import java.util.List;
+
+public interface ProductRepositoryCustom {
+    List<Product> searchByTokens(List<String> tokens);
+}

--- a/src/main/java/com/lokoko/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/product/repository/ProductRepositoryImpl.java
@@ -1,0 +1,78 @@
+package com.lokoko.domain.product.repository;
+
+import static com.lokoko.domain.product.entity.QProduct.product;
+
+import com.lokoko.domain.product.entity.Product;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ProductRepositoryImpl implements ProductRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Product> searchByTokens(List<String> tokens) {
+
+        if (tokens.isEmpty()) {
+            return List.of();
+        }
+
+        // 1단계: 완전 일치 검색
+        String fullKeyword = String.join("", tokens);
+        List<Product> exactMatches = queryFactory
+                .selectFrom(product)
+                .where(product.searchToken.containsIgnoreCase(fullKeyword))
+                .fetch();
+
+        if (!exactMatches.isEmpty()) {
+            return exactMatches; // 완전 일치 결과가 있으면 바로 반환
+        }
+
+        // 2단계: 모든 토큰 포함 검색 (AND match)
+        BooleanBuilder allTokensMatch = new BooleanBuilder();
+        tokens.forEach(token ->
+                allTokensMatch.and(product.searchToken.containsIgnoreCase(token))
+        );
+
+        List<Product> allTokenMatches = queryFactory
+                .selectFrom(product)
+                .where(allTokensMatch)
+                .fetch();
+
+        if (!allTokenMatches.isEmpty()) {
+            return allTokenMatches; // 모든 토큰 일치 결과가 있으면 반환
+        }
+
+        // 3단계: 주요 토큰만 검색 (브랜드명이나 상품명)
+        // 토큰이 3개 이상인 경우만 적용
+        if (tokens.size() >= 3) {
+            BooleanBuilder majorTokensMatch = new BooleanBuilder();
+            // 첫 번째 토큰(보통 브랜드명)과 마지막 토큰 조합
+            majorTokensMatch.and(product.searchToken.containsIgnoreCase(tokens.get(0)))
+                    .and(product.searchToken.containsIgnoreCase(tokens.get(tokens.size() - 1)));
+
+            List<Product> majorMatches = queryFactory
+                    .selectFrom(product)
+                    .where(majorTokensMatch)
+                    .fetch();
+
+            if (!majorMatches.isEmpty()) {
+                return majorMatches;
+            }
+        }
+
+        // 4단계: 일부 토큰 검색 (OR match)
+        BooleanBuilder anyTokenMatch = new BooleanBuilder();
+        tokens.forEach(token ->
+                anyTokenMatch.or(product.searchToken.containsIgnoreCase(token))
+        );
+
+        return queryFactory
+                .selectFrom(product)
+                .where(anyTokenMatch)
+                .fetch();
+    }
+}

--- a/src/main/java/com/lokoko/domain/product/service/ProductService.java
+++ b/src/main/java/com/lokoko/domain/product/service/ProductService.java
@@ -9,6 +9,7 @@ import static java.util.stream.Collectors.toList;
 import com.lokoko.domain.image.entity.ProductImage;
 import com.lokoko.domain.image.repository.ProductImageRepository;
 import com.lokoko.domain.product.dto.CategoryProductResponse;
+import com.lokoko.domain.product.dto.NameBrandProductResponse;
 import com.lokoko.domain.product.dto.ProductResponse;
 import com.lokoko.domain.product.dto.ProductSummary;
 import com.lokoko.domain.product.entity.Product;
@@ -20,6 +21,7 @@ import com.lokoko.domain.product.exception.SubCategoryNotFoundException;
 import com.lokoko.domain.product.repository.ProductRepository;
 import com.lokoko.domain.review.entity.enums.Rating;
 import com.lokoko.domain.review.repository.ReviewRepository;
+import com.lokoko.global.kuromoji.service.KuromojiService;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Arrays;
@@ -35,10 +37,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ProductService {
-
     private final ProductRepository productRepository;
     private final ProductImageRepository productImageRepository;
     private final ReviewRepository reviewRepository;
+    private final KuromojiService kuromojiService;
 
     // 카테고리 id 로 제품 리스트 조회
     public CategoryProductResponse searchProductsByCategory(String middleCategoryId, String subCategoryId) {
@@ -59,6 +61,45 @@ public class ProductService {
             products = productRepository.findByMiddleCategory(middleCategory);
         }
 
+        List<ProductResponse> productResponses = buildProductResponseWithReviewData(products);
+
+        // 최종 DTO 반환
+        if (subCategory == null) { // Middle 카테고리만으로 검색 한 경우
+            return new CategoryProductResponse(
+                    middleCategory.getDisplayName(),
+                    middleCategory.getParent().getDisplayName(),
+                    middleCategory.getDisplayName(),
+                    products.size(),
+                    productResponses);
+
+        }
+
+        // Middle, Sub 카테고리 모두 사용하여 검색 한 경우
+        return new CategoryProductResponse(
+                subCategory.getDisplayName(), //사용자의 검색어 (searchQuery)
+                subCategory.getMiddleCategory().getParent().getDisplayName(), // 서브 카테고리 부모 이름
+                subCategory.getDisplayName(), //사용자가 검색한 서브 카테고리 이름
+                products.size(), // 검색 결과 상품 수
+                productResponses); // 검색 결과 상품 list
+
+    }
+
+    public NameBrandProductResponse search(String keyword) {
+
+        List<String> tokens = kuromojiService.tokenize(keyword);
+        List<Product> products = productRepository.searchByTokens(tokens);
+
+        List<ProductResponse> productResponses = buildProductResponseWithReviewData(products);
+
+        return new NameBrandProductResponse(
+                keyword,
+                products.size(),
+                productResponses
+        );
+
+    }
+
+    private List<ProductResponse> buildProductResponseWithReviewData(List<Product> products) {
         // 제품과 관련있는 이미지들을 한번에 in 쿼리로 받아오기 위해, product 의 Id 만 리스트로 가져온다.
         List<Long> productIds = getProductIds(products);
 
@@ -103,25 +144,7 @@ public class ProductService {
         // 최종적으로 클라이언트에게 반환될 DTO를 만드는 과정
         List<ProductResponse> productResponses = makeProductResponse(products, summaryMap);
 
-        // 최종 DTO 반환
-        if (subCategory == null) { // Middle 카테고리만으로 검색 한 경우
-            return new CategoryProductResponse(
-                    middleCategory.getDisplayName(),
-                    middleCategory.getParent().getDisplayName(),
-                    middleCategory.getDisplayName(),
-                    products.size(),
-                    productResponses);
-
-        }
-
-        // Middle, Sub 카테고리 모두 사용하여 검색 한 경우
-        return new CategoryProductResponse(
-                subCategory.getDisplayName(), //사용자의 검색어 (searchQuery)
-                subCategory.getMiddleCategory().getParent().getDisplayName(), // 서브 카테고리 부모 이름
-                subCategory.getDisplayName(), //사용자가 검색한 서브 카테고리 이름
-                products.size(), // 검색 결과 상품 수
-                productResponses); // 검색 결과 상품 list
-
+        return productResponses;
     }
 
     private void aggregateReviewStats(List<Object[]> reviewStats,
@@ -190,8 +213,8 @@ public class ProductService {
         }
         return summaryMap;
     }
-
     // 현재는, 사용되지 않으나 상품 상세조회에서 사용됨
+
     private void calculateRatingRatioForProduct(Map<Rating, Long> ratingCounts, long totalReviews,
                                                 Long productId) {
         // 상품의 별점별 비율 계산 하기
@@ -203,7 +226,7 @@ public class ProductService {
 
         for (Map.Entry<Rating, Long> ratingEntry : ratingCounts.entrySet()) {
             Rating rating = ratingEntry.getKey(); // 별점 값
-            Long count = ratingEntry.getValue(); // 그 별점의 개수 
+            Long count = ratingEntry.getValue(); // 그 별점의 개수
 
             BigDecimal ratio = valueOf(count)
                     .multiply(valueOf(100))
@@ -267,16 +290,16 @@ public class ProductService {
                 .findFirst()
                 .orElseThrow(MiddleCategoryNotFoundException::new);
     }
-
     // 클라이언트에서 카테고리 number 를 전달하므로, 이 number 에 해당하는 카테고리 이름을 검색해야함.
+
     private SubCategory getSubCategory(String subCategoryId) {
         return Arrays.stream(SubCategory.values())
                 .filter(sub -> sub.getCtgrNo().equals(subCategoryId))
                 .findFirst()
                 .orElseThrow(SubCategoryNotFoundException::new);
     }
-
     // 제품을 내림차순(리뷰 수 기준)으로 정렬하는 메소드. 리뷰 수가 같을 경우 평균 별점 내림차순으로 정렬
+
     private void sortProductByReviewCountAndRating(List<Product> products, Map<Long, Long> reviewCountMap,
                                                    Map<Long, BigDecimal> ratingMap) {
         products.sort((p1, p2) -> {

--- a/src/main/java/com/lokoko/global/config/KuromojiConfig.java
+++ b/src/main/java/com/lokoko/global/config/KuromojiConfig.java
@@ -1,0 +1,22 @@
+package com.lokoko.global.config;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.ja.JapaneseTokenizer;
+import org.apache.lucene.analysis.ja.JapaneseTokenizer.Mode;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class KuromojiConfig {
+
+    @Bean
+    public Analyzer japaneseAnalyzer() {
+        return new Analyzer() {
+            @Override
+            protected TokenStreamComponents createComponents(String fieldName) {
+                JapaneseTokenizer tokenizer = new JapaneseTokenizer(null, false, Mode.SEARCH);
+                return new TokenStreamComponents(tokenizer);
+            }
+        };
+    }
+}

--- a/src/main/java/com/lokoko/global/kuromoji/controller/KuromojiController.java
+++ b/src/main/java/com/lokoko/global/kuromoji/controller/KuromojiController.java
@@ -1,0 +1,22 @@
+package com.lokoko.global.kuromoji.controller;
+
+import com.lokoko.global.kuromoji.service.KuromojiService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/kuromoji")
+@RequiredArgsConstructor
+public class KuromojiController {
+
+    private final KuromojiService kuromojiService;
+
+    @GetMapping("/tokenize")
+    public List<String> tokenize(@RequestParam String text) {
+        return kuromojiService.tokenize(text);
+    }
+}

--- a/src/main/java/com/lokoko/global/kuromoji/controller/ProductMigrationController.java
+++ b/src/main/java/com/lokoko/global/kuromoji/controller/ProductMigrationController.java
@@ -1,0 +1,23 @@
+package com.lokoko.global.kuromoji.controller;
+
+import com.lokoko.global.kuromoji.service.ProductMigrationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/migration")
+public class ProductMigrationController {
+
+    private final ProductMigrationService productMigrationService;
+
+    @PostMapping("/update-search-fields")
+    public ResponseEntity<String> updateSearchFields() {
+        productMigrationService.migrateSearchFields();
+        return ResponseEntity.ok("검색 필드 업데이트 완료");
+    }
+}
+

--- a/src/main/java/com/lokoko/global/kuromoji/exception/ErrorMessage.java
+++ b/src/main/java/com/lokoko/global/kuromoji/exception/ErrorMessage.java
@@ -1,0 +1,13 @@
+package com.lokoko.global.kuromoji.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    TOKENIZE_FAILED("토큰화에 실패하였습니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/lokoko/global/kuromoji/exception/TokenizeFailedException.java
+++ b/src/main/java/com/lokoko/global/kuromoji/exception/TokenizeFailedException.java
@@ -1,0 +1,11 @@
+package com.lokoko.global.kuromoji.exception;
+
+
+import com.lokoko.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class TokenizeFailedException extends BaseException {
+    public TokenizeFailedException() {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, ErrorMessage.TOKENIZE_FAILED.getMessage());
+    }
+}

--- a/src/main/java/com/lokoko/global/kuromoji/service/KuromojiService.java
+++ b/src/main/java/com/lokoko/global/kuromoji/service/KuromojiService.java
@@ -1,0 +1,34 @@
+package com.lokoko.global.kuromoji.service;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KuromojiService {
+
+    private final Analyzer analyzer;
+
+    public List<String> tokenize(String text) {
+        List<String> out = new ArrayList<>();
+        try (TokenStream ts = analyzer.tokenStream(null, new StringReader(text))) {
+            ts.reset();
+            CharTermAttribute termAtt = ts.addAttribute(CharTermAttribute.class);
+            while (ts.incrementToken()) {
+                out.add(termAtt.toString());
+            }
+            ts.end();
+        } catch (IOException e) {
+            throw new RuntimeException("Tokenizing failed", e);
+        }
+        return out;
+    }
+
+}

--- a/src/main/java/com/lokoko/global/kuromoji/service/KuromojiService.java
+++ b/src/main/java/com/lokoko/global/kuromoji/service/KuromojiService.java
@@ -1,5 +1,6 @@
 package com.lokoko.global.kuromoji.service;
 
+import com.lokoko.global.kuromoji.exception.TokenizeFailedException;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
@@ -26,7 +27,7 @@ public class KuromojiService {
             }
             ts.end();
         } catch (IOException e) {
-            throw new RuntimeException("Tokenizing failed", e);
+            throw new TokenizeFailedException();
         }
         return out;
     }

--- a/src/main/java/com/lokoko/global/kuromoji/service/ProductMigrationService.java
+++ b/src/main/java/com/lokoko/global/kuromoji/service/ProductMigrationService.java
@@ -1,0 +1,40 @@
+package com.lokoko.global.kuromoji.service;
+
+import com.lokoko.domain.product.entity.Product;
+import com.lokoko.domain.product.repository.ProductRepository;
+import jakarta.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProductMigrationService {
+
+    private final ProductRepository productRepository;
+    private final KuromojiService kuromojiProcessor;
+
+    @Transactional
+    public void migrateSearchFields() {
+        List<Product> allProducts = productRepository.findAll();
+
+        for (Product product : allProducts) {
+            String name = product.getProductName();
+            String brand = product.getBrandName();
+
+            List<String> tokens = new ArrayList<>();
+            if (name != null && !name.isBlank()) {
+                tokens.addAll(kuromojiProcessor.tokenize(name));
+            }
+
+            if (brand != null && !brand.isBlank()) {
+                tokens.addAll(kuromojiProcessor.tokenize(brand));
+            }
+
+            String joinedTokens = String.join(" ", tokens);
+            product.updateSearchToken(joinedTokens);
+        }
+    }
+
+}


### PR DESCRIPTION
## Related issue 🛠

- closed #40 

## 작업 내용 💻

- [일본어 형태소 분석기인 Kuromoji 의존성을 추가하였습니다.] 

Kuromoji 의존성은 두 가지중 하나를 선택할 수 있었는데요, atilika / lucene 중 후자를 선택했습니다. 
그 이유는, 추후 "검색어 자동완성" 기능을 구현하려면 Elastic Search 의 도입이 필요하고,
lucene 버전이 Elastic Search 와 호환성이 좋기 때문입니다.

- [Product 엔티티의 필드가 새롭게 추가되었습니다.]

Product 엔티티의 필드에 "searchToken" 이라는 필드가 추가되었습니다.
해당 필드에는 토큰화된 문자열들이 저장됩니다.
이해를 돕기 위해 예를 들어봅시다.

상품명 : HERA ブラッククッションファンデーション
브랜드명 : HERA

위와 같은 정보를 가지고 있는 상품이 있다고 해봅시다.
Kuromoji 의 JapanseAnalyzer (일본어 분석기) 는 ,
제품의 상품명, 브랜드명을 토큰(의미) 단위로 나누어줍니다.

이 두 정보를 가지고 토큰화를 한 결과는,
HERA    ブラック   クッション   ファンデーション   HERA
위처럼 나오게 됩니다.

HERA 
ブラック (블랙)
クッション(쿠션)
ファンデーション(파운데이션)
HERA

의미를 가진 단어들이 잘 토큰화된 것을 볼 수 있죠.
이 정보들이 searchToken 에 저장되는 것입니다.

<img width="453" alt="image" src="https://github.com/user-attachments/assets/d2dd2c69-d979-43be-9e6a-f5739b448fbe" />

사진을 보시면 , 다른 제품들에 대한 토큰화 결과입니다.
근데.. 토큰화가 그렇게 세밀하게 이루어지는 것은 아닙니다. 더 쪼갤 수 있는데 안 쪼개진 단어들도 몇몇 보입니다.
여러 옵션을 줘서 테스트 해봤는데, 옵션을 세게 주면 너무 잘게 나누어져버리고, 약하게 주면 나뉘는게 거의 없어서 중간 정도의 옵션을 선택했습니다. 

- [QueryDSL 기반으로 상품명 / 브랜드명 기준으로 상품 검색 기능 구현]

QueryDSL 을 사용하여 상품명 / 브랜드명 기준으로 상품 검색 기능을 구현했습니다.
ProductRepositoryImpl 에서 볼 수 있듯이, 1단계 -> 2단계 - >... 4단계 까지 검색의 우선순위를 구분해 놓았습니다.



## 스크린샷 📷

다양한 검색 결과 케이스
1) アヌア(아누아)  로 검색 (브랜드명)
<img width="536" alt="image" src="https://github.com/user-attachments/assets/3b32a006-6c00-4d04-a9aa-d5cb1a865d2a" />

2)  ア(아) 로 검색
<img width="707" alt="image" src="https://github.com/user-attachments/assets/7e219334-635d-4e3d-b378-1488e765552f" />


3) クッション (쿠션) 으로 검색
<img width="820" alt="image" src="https://github.com/user-attachments/assets/2337f129-eb70-4e30-90af-eb44cb07edd1" />


4) HERA (브랜드 명을 영어로 검색)
<img width="752" alt="image" src="https://github.com/user-attachments/assets/736ceaa6-1266-4b8f-b6c4-5aa8be7e89b3" />



## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

1. 더 다양한 검색 케이스에 대해 테스트 해봐야 할 것 같습니다.

2. Kuromoji 는 일본어에서 탁음 / 반탁음을 구분하지 못하는 것 같습니다.

우선 탁음과 반탁음에 대한 설명부터 하자면...
일본어에서는 へ (he/헤) 라는 히라가나가 있습니다. 
여기에 점 두개를 붙이면 탁음이되고, 동그라미 하나를 붙이면 반탁음이 됩니다. 아래처럼요.
###べ(be/베)　### ぺ(pe/페)  

/api/products/search?keyword=べ 
위처럼, 저는 be 를 keyword 로 줘서 검색을 수행했는데도 불구하고 결과는 아래 사진처럼 나왔습니다.
<img width="704" alt="image" src="https://github.com/user-attachments/assets/57e28b56-46f2-49b6-9c09-cf82467d2801" />

べ 도 포함되어 있고, ぺ 도 포함되어있죠..
LIPS, COSME, OLIVE YOUNG GLOBAL 은 어떤지 확인을 해봐야 할 것 같습니다.









